### PR TITLE
bugfix(VNC): do not autoconnect to indicate loading

### DIFF
--- a/images/vnc/vnc/index.html
+++ b/images/vnc/vnc/index.html
@@ -31,7 +31,7 @@
     </iframe>
 
     <script type="text/javascript">
-      let url = "vnc.html?resize=remote&autoconnect=1&path=";
+      let url = "vnc.html?resize=remote&autoconnect=0&path=";
       let path = "websockify";
       if (window.location.pathname) {
         // change the path depending on window.location (necessary for websockets to work on Coder's application path


### PR DESCRIPTION
noVNC does not have a loading indicator, but adding a "Connect" button will indicate VNC is working as expected instead of a black screen.