### PR TITLE
add phpstorm and php interpreter dockerfiles

### DIFF
--- a/images/phpstorm/Dockerfile.centos
+++ b/images/phpstorm/Dockerfile.centos
@@ -1,0 +1,24 @@
+FROM codercom/enterprise-multieditor:centos
+
+# Run everything as root
+USER root
+
+# Install php interpreter and CGI
+RUN yum update -y && yum install -y \
+    php \
+    php-common \
+    php-fpm \
+    php-opcache \
+    php-cli \
+    php-pear \
+    php-devel  
+
+# Install phpstorm.
+RUN mkdir -p /opt/ps
+RUN curl -L "https://download.jetbrains.com/product?code=PS&latest&distribution=linux" | tar -C /opt/ps --strip-components 1 -xzvf -
+
+# Add a binary to the PATH that points to the intellij startup script.
+RUN ln -s /opt/ps/bin/phpstorm.sh /usr/bin/phpstorm
+
+# Set back to coder user
+USER coder

--- a/images/phpstorm/Dockerfile.ubuntu
+++ b/images/phpstorm/Dockerfile.ubuntu
@@ -1,0 +1,23 @@
+FROM codercom/enterprise-multieditor:ubuntu
+
+# Run everything as root
+USER root
+
+# Install php interpreter and CGI
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
+      php \
+      php7.4-cgi \
+      php-xdebug \
+      php-dev    
+
+# Install phpstorm.
+RUN mkdir -p /opt/ps
+RUN curl -L "https://download.jetbrains.com/product?code=PS&latest&distribution=linux" | tar -C /opt/ps --strip-components 1 -xzvf -
+
+# Add a binary to the PATH that points to the intellij startup script.
+RUN ln -s /opt/ps/bin/phpstorm.sh /usr/bin/phpstorm
+
+# Set back to coder user
+USER coder

--- a/images/phpstorm/README.md
+++ b/images/phpstorm/README.md
@@ -1,0 +1,13 @@
+# Enterprise PhpStorm
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-phpstorm?label=codercom%2Fenterprise-phpstorm)](https://hub.docker.com/r/codercom/enterprise-phpstorm)
+
+## Description
+
+Wraps [enterprise-multieditor](../multieditor/README.md) with PhpStorm
+installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments created
+from this image will be able to launch PhpStorm with the PHP interpreter included.


### PR DESCRIPTION
creating ubuntu and centos Dockerfiles for JetBrains PhpStorm IDE and these include a PHP interpreter.  Inherits multi-editor image for JetBrains browser IDE support.