### PR TITLE
chore: disable fail-fast for image build job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,7 @@ jobs:
           - arch
           - centos
           - ubuntu
+      fail-fast: false
     name: images/${{ matrix.job}}
     steps:
       - name: Cancel previous runs


### PR DESCRIPTION
The CentOS and Arch builds are currently broken, but this change is needed to unblock updates to the Ubuntu image.