### PR TITLE
chore: switch from named to numeric uids

### DIFF
--- a/images/android/Dockerfile.ubuntu
+++ b/images/android/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-java:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 ENV ANDROID_SDK_ROOT /usr/lib/android-sdk
 ENV ANDROID_HOME ${ANDROID_SDK_ROOT}
@@ -38,4 +38,4 @@ RUN add-apt-repository ppa:maarten-fonville/android-studio && \
     ln -s /opt/android-studio/bin/studio.sh /usr/local/bin/studio
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/base/Dockerfile.arch
+++ b/images/base/Dockerfile.arch
@@ -41,7 +41,7 @@ RUN useradd coder \
       --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
-USER coder
+USER 1000
 
 # install Homebrew, must be as a non-root user
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -42,7 +42,7 @@ RUN useradd coder \
       --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
-USER coder
+USER 1000
 
 # install Homebrew, must be as a non-root user
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -42,7 +42,7 @@ RUN useradd coder \
       --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
-USER coder
+USER 1000
 
 # install Homebrew, must be as a non-root user
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/images/clion/Dockerfile.centos
+++ b/images/clion/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install clion.
 RUN mkdir -p /opt/clion
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=CL&latest&distribution=
 RUN ln -s /opt/clion/bin/clion.sh /usr/bin/clion
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/clion/Dockerfile.ubuntu
+++ b/images/clion/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install clion.
 RUN mkdir -p /opt/clion
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=CL&latest&distribution=
 RUN ln -s /opt/clion/bin/clion.sh /usr/bin/clion
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/dataSpell/Dockerfile.centos
+++ b/images/dataSpell/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install DataSpell.
 RUN mkdir -p /opt/dataspell
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/python/jetbrains-data-spell-213.2094
 RUN ln -s /opt/dataspell/bin/dataspell.sh /usr/bin/dataspell
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/dataSpell/Dockerfile.ubuntu
+++ b/images/dataSpell/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install DataSpell.
 RUN mkdir -p /opt/dataspell
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/python/jetbrains-data-spell-213.2094
 RUN ln -s /opt/dataspell/bin/dataspell.sh /usr/bin/dataspell
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/goland/Dockerfile.centos
+++ b/images/goland/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-golang:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Packages required for multi-editor support
 RUN yum update -y && yum install -y \
@@ -21,4 +21,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=GO&latest&distribution=
 RUN ln -s /opt/goland/bin/goland.sh /usr/bin/goland
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/goland/Dockerfile.ubuntu
+++ b/images/goland/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-golang:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Packages required for multi-editor support
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
@@ -19,4 +19,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=GO&latest&distribution=
 RUN ln -s /opt/goland/bin/goland.sh /usr/bin/goland
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/golang/Dockerfile.centos
+++ b/images/golang/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install go
 RUN curl -L "https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
@@ -15,4 +15,4 @@ ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOBIN
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/golang/Dockerfile.ubuntu
+++ b/images/golang/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install go
 RUN curl -L "https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
@@ -15,4 +15,4 @@ ENV GOBIN $GOPATH/bin
 ENV PATH $PATH:$GOBIN
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/intellij/Dockerfile.centos
+++ b/images/intellij/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-java:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Packages required for multi-editor support
 RUN yum update -y && yum install -y \
@@ -21,4 +21,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=IIC&latest&distribution
 RUN ln -s /opt/idea/bin/idea.sh /usr/bin/intellij-idea-ultimate
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/intellij/Dockerfile.ubuntu
+++ b/images/intellij/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-java:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Packages required for multi-editor support
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
@@ -19,4 +19,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=IIC&latest&distribution
 RUN ln -s /opt/idea/bin/idea.sh /usr/bin/intellij-idea-community
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/java/Dockerfile.centos
+++ b/images/java/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install JDK (OpenJDK 8)
 RUN yum install -y java-1.8.0-openjdk-devel
@@ -52,4 +52,4 @@ RUN mkdir -p /usr/share/gradle /usr/share/gradle/ref \
 ENV PATH $PATH:$GRADLE_HOME/bin
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/java/Dockerfile.ubuntu
+++ b/images/java/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install JDK (OpenJDK 8)
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-11-jdk
@@ -52,4 +52,4 @@ RUN mkdir -p /usr/share/gradle /usr/share/gradle/ref \
 ENV PATH $PATH:$GRADLE_HOME/bin
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/jupyter/Dockerfile.centos
+++ b/images/jupyter/Dockerfile.centos
@@ -1,11 +1,11 @@
 FROM codercom/enterprise-base:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install jupyter
 RUN pip3 install jupyter-core==4.7.1 && \
     pip3 install jupyterlab
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/jupyter/Dockerfile.ubuntu
+++ b/images/jupyter/Dockerfile.ubuntu
@@ -1,11 +1,11 @@
 FROM codercom/enterprise-base:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install jupyter
 RUN pip3 install jupyter-core==4.7.1 && \
     pip3 install jupyterlab
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/multieditor/Dockerfile.centos
+++ b/images/multieditor/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Packages required for multi-editor support
 RUN yum update -y && yum install -y \
@@ -14,4 +14,4 @@ RUN yum update -y && yum install -y \
     libGL
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/multieditor/Dockerfile.ubuntu
+++ b/images/multieditor/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Packages required for multi-editor support
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
@@ -12,4 +12,4 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     libgtk-3-0
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/node/Dockerfile.centos
+++ b/images/node/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install whichever Node version is LTS
 RUN curl -sL https://rpm.nodesource.com/setup_lts.x | bash -
@@ -12,4 +12,4 @@ RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum
 RUN yum install -y yarn
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/node/Dockerfile.ubuntu
+++ b/images/node/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install whichever Node version is LTS
 RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash -
@@ -13,4 +13,4 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 RUN DEBIAN_FRONTEND="noninteractive" apt-get update && apt-get install -y yarn
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/pycharm/Dockerfile.centos
+++ b/images/pycharm/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install pycharm.
 RUN mkdir -p /opt/pycharm
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=PCC&latest&distribution
 RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm-community
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/pycharm/Dockerfile.ubuntu
+++ b/images/pycharm/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install pycharm.
 RUN mkdir -p /opt/pycharm
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=PCC&latest&distribution
 RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm-community
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/ruby/Dockerfile.centos
+++ b/images/ruby/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install OpenSSL library
 RUN yum install -y openssl-devel
@@ -14,4 +14,4 @@ RUN chmod +x /tmp/install-ruby.sh && /tmp/install-ruby.sh
 RUN gem install bundler
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/ruby/Dockerfile.ubuntu
+++ b/images/ruby/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-base:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install OpenSSL library
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y libssl-dev
@@ -11,4 +11,4 @@ COPY ./install-ruby.sh /tmp
 RUN chmod +x /tmp/install-ruby.sh && /tmp/install-ruby.sh
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/vnc/Dockerfile.ubuntu
+++ b/images/vnc/Dockerfile.ubuntu
@@ -104,7 +104,7 @@ RUN $VNC_SETUP_SCRIPTS/set_user_permission.sh $VNC_ROOT_DIR \
 COPY ["./coder", "/coder"]
 RUN chmod +x /coder/configure
 
-USER coder
+USER 1000
 
 RUN $VNC_SETUP_SCRIPTS/no_vnc.sh
 

--- a/images/webstorm/Dockerfile.centos
+++ b/images/webstorm/Dockerfile.centos
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:centos
 
 # Run everything as root
-USER root
+USER 0
 
 # Install webstorm.
 RUN mkdir -p /opt/webstorm
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=WS&latest&distribution=
 RUN ln -s /opt/webstorm/bin/webstorm.sh /usr/bin/webstorm
 
 # Set back to coder user
-USER coder
+USER 1000

--- a/images/webstorm/Dockerfile.ubuntu
+++ b/images/webstorm/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM codercom/enterprise-multieditor:ubuntu
 
 # Run everything as root
-USER root
+USER 0
 
 # Install webstorm.
 RUN mkdir -p /opt/webstorm
@@ -11,4 +11,4 @@ RUN curl -L "https://download.jetbrains.com/product?code=WS&latest&distribution=
 RUN ln -s /opt/webstorm/bin/webstorm.sh /usr/bin/webstorm
 
 # Set back to coder user
-USER coder
+USER 1000


### PR DESCRIPTION
Clusters that have an admission controller that requires containers
to run as a non-root user need the default user of the image to be
declared as a numeric uid, so that the constraint can be applied
prior to starting the container.

Change "USER root" to "USER 0" and "USER coder" to "USER 1000"