### PR TITLE
chore: unpin arch version

### DIFF
--- a/images/base/Dockerfile.arch
+++ b/images/base/Dockerfile.arch
@@ -1,9 +1,6 @@
-FROM archlinux/archlinux:base-20210205.0.15146
+FROM archlinux/archlinux:base
 
 SHELL ["/bin/bash", "-c"]
-
-# Workaround broken upstream archive by pinning to older snapshot
-COPY mirrorlist /etc/pacman.d/mirrorlist
 
 # Install baseline packages
 RUN pacman --noconfirm -Syyuu \

--- a/images/base/mirrorlist
+++ b/images/base/mirrorlist
@@ -1,1 +1,0 @@
-Server=https://archive.archlinux.org/repos/2021/02/01/$repo/os/$arch


### PR DESCRIPTION
The pinned Arch version started failing during upgrade, so try
removing the version pin.