### PR TITLE
add dbus-x11 to VNC image

### DIFF
--- a/images/vnc/Dockerfile.ubuntu
+++ b/images/vnc/Dockerfile.ubuntu
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
   xfce4 \
   xfce4-goodies \
   x11-apps \
+  dbus-x11 \
   xterm \
   python-numpy \
   firefox \


### PR DESCRIPTION
While this dependency doesn't seem necessary for our current builds, this was discovered to be a missing dependency (therefore breaking VNC) when this image is forked, or perhaps used with a different base image