### PR TITLE
chore: downgrade runc version in ubuntu image

### DIFF
--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -9,12 +9,14 @@ COPY docker-archive-keyring.gpg /usr/share/keyrings/docker-archive-keyring.gpg
 COPY docker.list /etc/apt/sources.list.d/docker.list
 
 # Install baseline packages
+# We use an old containerd.io because it contains a version of runc that works
+# with sysbox correctly.
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
       bash \
       build-essential \
       ca-certificates \
-      containerd.io \
+      containerd.io=1.5.11-1 \
       curl \
       docker-ce \
       docker-ce-cli \


### PR DESCRIPTION
The runc included in the latest containerd.io package is incompatible with sysbox ATM.

https://github.com/nestybox/sysbox/issues/544