### PR TITLE
chore: pin containerd version

### DIFF
--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -2,6 +2,8 @@ FROM ubuntu:20.04
 
 SHELL ["/bin/bash", "-c"]
 
+COPY containerd-pin /etc/apt/preferences.d/
+
 # Install the Docker apt repository
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes ca-certificates

--- a/images/base/containerd-pin
+++ b/images/base/containerd-pin
@@ -1,0 +1,3 @@
+Package: containerd.io
+Pin: version 1.5.11-1
+Pin-Priority: 999


### PR DESCRIPTION
ensures that downstream images do not upgrade the `containerd` & `runc` versions