### PR TITLE
chore: fix centOS images

### DIFF
--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 SHELL ["/bin/bash", "-c"]
 

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -25,8 +25,12 @@ RUN dnf install --assumeyes epel-release && \
       wget && \
     dnf clean all
 
+# We use an old containerd.io because it contains a version of runc that works
+# with sysbox correctly.
 RUN dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
-    dnf install --assumeyes docker-ce && \
+    dnf install --assumeyes \
+      containerd.io-1.5.11-3.1.el8 \
+      docker-ce && \
     systemctl enable docker
 
 # Add docker-compose

--- a/images/jupyter/Dockerfile.centos
+++ b/images/jupyter/Dockerfile.centos
@@ -3,6 +3,10 @@ FROM codercom/enterprise-base:centos
 # Run everything as root
 USER root
 
+# Install required dependencies
+RUN dnf install --assumeyes \
+   platform-python-devel
+
 # Install jupyter
 RUN pip3 install jupyter-core==4.7.1 && \
     pip3 install jupyterlab

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -3,22 +3,24 @@
 set -euo pipefail
 
 IMAGES=(
-  # These must be built first because others build FROM these
+  # This image must always be built first.
   "base"
+
+  # These must be built first because others build FROM these
+  "configure"
+  "golang"
+  "java"
   "multieditor"
+  "node"
+  "ruby"
+  "vnc"
 
   # We can build these images in any order
   "android"
-  "configure"
-  "goland"
-  "golang"
-  "intellij"
-  "java"
-  "jupyter"
-  "node"
-  "pycharm"
-  "ruby"
-  "vnc"
-  "webstorm"
   "clion"
+  "goland"
+  "intellij"
+  "jupyter"
+  "pycharm"
+  "webstorm"
 )


### PR DESCRIPTION
This PR makes the following changes to fix CentOS image builds:
- Move to CentOS 8 stream hosted on quay.io as a base, as CentOS 8 is EOL
- Install required python deps for Jupyter image
- Fix dependency ordering of images when building
- Downgrade containerd to version compatible with sysbox (ref: #158)