### PR TITLE
Set LANG on base images

### DIFF
--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -38,7 +38,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-c
 RUN chmod +x /usr/local/bin/docker-compose
 
 # Make typing unicode characters in the terminal work.
-ENV LANG C.UTF-8
+ENV LANG en_US.UTF-8
 
 # Add a user `coder` so that you're not developing as the `root` user
 RUN useradd coder \

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -37,6 +37,9 @@ RUN dnf config-manager --add-repo https://download.docker.com/linux/centos/docke
 RUN curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 RUN chmod +x /usr/local/bin/docker-compose
 
+# Make typing unicode characters in the terminal work.
+ENV LANG C.UTF-8
+
 # Add a user `coder` so that you're not developing as the `root` user
 RUN useradd coder \
       --create-home \

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -46,6 +46,9 @@ RUN systemctl enable docker
 RUN curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 RUN chmod +x /usr/local/bin/docker-compose
 
+# Make typing unicode characters in the terminal work.
+ENV LANG C.UTF-8
+
 # Add a user `coder` so that you're not developing as the `root` user
 RUN useradd coder \
       --create-home \

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -47,7 +47,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/v2.5.0/docker-c
 RUN chmod +x /usr/local/bin/docker-compose
 
 # Make typing unicode characters in the terminal work.
-ENV LANG C.UTF-8
+ENV LANG en_US.UTF-8
 
 # Add a user `coder` so that you're not developing as the `root` user
 RUN useradd coder \


### PR DESCRIPTION
This will make unicode in terminals work (the `UTF-8` part).

We could also explicitly use a specific language like `en_US` instead of `C` (`en_US.UTF-8`) but for now I figure we keep the status quo there especially for base images.