### PR TITLE
Add rsync to enterprise-base

### DIFF
--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -22,7 +22,8 @@ RUN dnf install --assumeyes epel-release && \
       sudo \
       unzip \
       vim \
-      wget && \
+      wget \
+      rsync && \
     dnf clean all
 
 # We use an old containerd.io because it contains a version of runc that works

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -34,7 +34,8 @@ RUN apt-get update && \
       systemd-sysv \
       unzip \
       vim \
-      wget && \
+      wget \
+      rsync && \
     # Install latest Git using their official PPA
     add-apt-repository ppa:git-core/ppa && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes git


### PR DESCRIPTION
Very useful for v1->v2 migration, so we want to have rsync widely available.