### PR TITLE
use node 16 for GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install Node.js modules
         run: yarn install


### PR DESCRIPTION
Node 12 for GitHub actions is deprecated and I confirmed this works for our packages. 