### PR TITLE
chore!: deprecate homebrew, remove ruby install

### DIFF
--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -56,7 +56,7 @@ RUN HOMEBREW_INSTALL_FROM_API=1 /bin/bash -c "$(curl -fsSL https://raw.githubuse
 USER ROOT
 
 # install our deprecation message wrapper for homebrew
-COPY --chown=root:root --chmod=755 homebrew-wrapper.sh /usr/local/bin/brew
+COPY homebrew-wrapper.sh /usr/local/bin/brew
 # remove the bundled ruby from homebrew to save space, homebrew reinstalls
 # anyways
 RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -52,4 +52,13 @@ USER coder
 
 # install Homebrew, must be as a non-root user
 RUN HOMEBREW_INSTALL_FROM_API=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-ENV PATH /home/linuxbrew/.linuxbrew/bin:${PATH}
+
+USER ROOT
+
+# install our deprecation message wrapper for homebrew
+COPY --chown=root:root --chmod=755 homebrew-wrapper.sh /usr/local/bin/brew
+# remove the bundled ruby from homebrew to save space, homebrew reinstalls
+# anyways
+RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby
+
+USER CODER

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -61,12 +61,7 @@ USER coder
 # install Homebrew, must be as a non-root user
 RUN HOMEBREW_INSTALL_FROM_API=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-USER ROOT
-
 # install our deprecation message wrapper for homebrew
-COPY --chown=root:root --chmod=755 homebrew-wrapper.sh /usr/local/bin/brew
-# remove the bundled ruby from homebrew to save space, homebrew reinstalls
-# anyways
-RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby
-
-USER CODER
+COPY homebrew-wrapper.sh /usr/local/bin/brew
+RUN sudo chown root:root /usr/local/bin/brew && \
+    sudo chmod 755 /usr/local/bin/brew

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -60,4 +60,13 @@ USER coder
 
 # install Homebrew, must be as a non-root user
 RUN HOMEBREW_INSTALL_FROM_API=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-ENV PATH /home/linuxbrew/.linuxbrew/bin:${PATH}
+
+USER ROOT
+
+# install our deprecation message wrapper for homebrew
+COPY --chown=root:root --chmod=755 homebrew-wrapper.sh /usr/local/bin/brew
+# remove the bundled ruby from homebrew to save space, homebrew reinstalls
+# anyways
+RUN rm -rf /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby
+
+USER CODER

--- a/images/base/homebrew-wrapper.sh
+++ b/images/base/homebrew-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+brew_bin="/home/linuxbrew/.linuxbrew/bin/brew"
+prefix="WARNING: "
+if [ -t 1 ]; then
+  # If stdout is a terminal, use color.
+  prefix="\033[1;33m${prefix}\033[0m"
+fi
+
+warning() {
+    echo "${prefix}Homebrew in Coder images is deprecated and will be removed at the end of March 2023." 1>&2
+}
+
+warning
+echo
+"$brew_bin" "$@"
+echo
+warning


### PR DESCRIPTION
Homebrew is deprecated and will be removed at the end of March 2023.

Homebrew reinstalls the bundled ruby if it's unavailable, so this helps us save space in the short term until Homebrew is removed.