### PR TITLE
fix(images/java): upgrade maven to 3.9.3

### DIFF
--- a/images/java/Dockerfile.ubuntu
+++ b/images/java/Dockerfile.ubuntu
@@ -18,7 +18,7 @@ ENV MAVEN_CONFIG "/home/coder/.m2"
 
 RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
   && echo "Downloading maven" \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   \
   && echo "Checking downloaded file hash" \
   && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c - \

--- a/images/java/Dockerfile.ubuntu
+++ b/images/java/Dockerfile.ubuntu
@@ -10,15 +10,15 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH $PATH:$JAVA_HOME/bin
 
 # Install Maven
-ARG MAVEN_VERSION=3.6.3
-ARG MAVEN_SHA512=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+ARG MAVEN_VERSION=3.9.3
+ARG MAVEN_SHA512=400fc5b6d000c158d5ee7937543faa06b6bda8408caa2444a9c947c21472fde0f0b64ac452b8cec8855d528c0335522ed5b6c8f77085811c7e29e1bedbb5daa2
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "/home/coder/.m2"
 
 RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
   && echo "Downloading maven" \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   \
   && echo "Checking downloaded file hash" \
   && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c - \


### PR DESCRIPTION
Previous version of maven is no longer available from OSU.

```
Step 10/16 : RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref   && echo "Downloading maven"   && curl -fsSL -o /tmp/apache-maven.tar.gz [https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz](https://apache.osuosl.org/maven/maven-3/$%7BMAVEN_VERSION%7D/binaries/apache-maven-$%7BMAVEN_VERSION%7D-bin.tar.gz)     && echo "Checking downloaded file hash"   && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c -     && echo "Unzipping maven"   && tar -xzf /tmp/apache-maven.tar.gz -C $MAVEN_HOME --strip-components=1     && echo "Cleaning and setting links"   && rm -f /tmp/apache-maven.tar.gz   && ln -s $MAVEN_HOME/bin/mvn /usr/bin/mvn
     ---> Running in 49882ae5ae1e
    Downloading maven
    curl: (22) The requested URL returned error: 404 Not Found
```