### PR TITLE
feat: build multiarch images

### DIFF
--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -12,6 +12,7 @@ COPY docker.list /etc/apt/sources.list.d/docker.list
 # Install baseline packages
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
+      -o Debug::pkgProblemResolver=yes \
       bash \
       build-essential \
       ca-certificates \
@@ -19,6 +20,7 @@ RUN apt-get update && \
       curl \
       docker-ce \
       docker-ce-cli \
+      docker-buildx-plugin \
       docker-compose-plugin \
       htop \
       locales \

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -12,7 +12,6 @@ COPY docker.list /etc/apt/sources.list.d/docker.list
 # Install baseline packages
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
-      -o Debug::pkgProblemResolver=yes \
       bash \
       build-essential \
       ca-certificates \

--- a/images/base/docker.list
+++ b/images/base/docker.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable
+deb [signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -100,7 +100,7 @@ for image in "${IMAGES[@]}"; do
     continue
   fi
 
-  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load \
+  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/arm64,linux/amd64,linux/arm/v7 \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -7,6 +7,7 @@ source "./lib.sh"
 
 check_dependencies \
   docker
+  depot
 
 source "./images.sh"
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -100,7 +100,7 @@ for image in "${IMAGES[@]}"; do
     continue
   fi
 
-  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/arm64,linux/amd64,linux/arm/v7 \
+  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/arm64,linux/amd64,linux/arm/v7 --save --metadata-file=build.json \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -7,6 +7,7 @@ source "./lib.sh"
 
 check_dependencies \
   docker
+  depot
 
 source "./images.sh"
 

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -100,7 +100,6 @@ for image in "${IMAGES[@]}"; do
     continue
   fi
 
-  run_trace $DRY_RUN docker push \
-    "${docker_flags[@]}" \
-    "$image_ref" \| indent
+  build_id=$(cat build.json | jq -r .\[\"depot.build\"\].buildID)
+  run_trace $DRY_RUN depot push --project "gb3p8xrshk" "$build_id" 
 done


### PR DESCRIPTION
closes #185, closes #237 

> [!IMPORTANT]
> The build and push script requires depot CLI to be set up and fail if run locally and the depot is unavailable. We can add a fallback method to use docker CLI in a follow-up PR (docker needs a bit more work to push multi-arch image manifest)
