### PR TITLE
feat: add `latest` tag

### DIFF
--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -102,5 +102,5 @@ for image in "${IMAGES[@]}"; do
   fi
 
   build_id=$(cat build.json | jq -r .\[\"depot.build\"\].buildID)
-  run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$image_ref" --tag "codercom/enterprise-$image:latest" "$build_id" 
+  run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$image_ref" --tag "codercom/enterprise-${image}:latest" "$build_id" 
 done

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -102,5 +102,5 @@ for image in "${IMAGES[@]}"; do
   fi
 
   build_id=$(cat build.json | jq -r .\[\"depot.build\"\].buildID)
-  run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$image_ref" "$build_id" 
+  run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$image_ref" --tag "codercom/enterprise-$image:latest" "$build_id" 
 done


### PR DESCRIPTION
Now we only publish 'ubuntu' images and have deprecated `centos` in #238. So adding 'latest' as the tag will allow pulling with `docker pull codercom/enterprise-minimal` or `FROM codercom/enterprise-minimal`