### PR TITLE
chore: use `docker-compose` binary from the `docker-compose-plugin` pkg

### DIFF
--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -41,7 +41,7 @@ RUN apt-get update && \
 # Enables Docker starting with systemd
 RUN systemctl enable docker
 
-# Create a symlink for standalone docker-compsoe usage
+# Create a symlink for standalone docker-compose usage
 RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
 
 # Make typing unicode characters in the terminal work.

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -41,9 +41,8 @@ RUN apt-get update && \
 # Enables Docker starting with systemd
 RUN systemctl enable docker
 
-# Add docker-compose
-RUN curl -L "https://github.com/docker/compose/releases/download/v2.16.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-RUN chmod +x /usr/local/bin/docker-compose
+# Create a symlink for standalone docker-compsoe usage
+RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
 
 # Make typing unicode characters in the terminal work.
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
I have tested this with a local build
```console
coder@ff439c7348c2:/$ which docker
/usr/bin/docker
coder@ff439c7348c2:/$ which docker-compose
/usr/bin/docker-compose
coder@ff439c7348c2:/$ docker-compose

Usage:  docker compose [OPTIONS] COMMAND

Define and run multi-container applications with Docker.

Options:
      --ansi string                Control when to print ANSI control characters ("never"|"always"|"auto") (default "auto")
      --compatibility              Run compose in backward compatibility mode
      --dry-run                    Execute command in dry run mode
      --env-file stringArray       Specify an alternate environment file.
  -f, --file stringArray           Compose configuration files
      --parallel int               Control max parallelism, -1 for unlimited (default -1)
      --profile stringArray        Specify a profile to enable
      --progress string            Set type of progress output (auto, tty, plain, quiet) (default "auto")
      --project-directory string   Specify an alternate working directory
                                   (default: the path of the, first specified, Compose file)
  -p, --project-name string        Project name

Commands:
  build       Build or rebuild services
  config      Parse, resolve and render compose file in canonical format
  cp          Copy files/folders between a service container and the local filesystem
  create      Creates containers for a service.
  down        Stop and remove containers, networks
  events      Receive real time events from containers.
  exec        Execute a command in a running container.
  images      List images used by the created containers
  kill        Force stop service containers.
  logs        View output from containers
  ls          List running compose projects
  pause       Pause services
  port        Print the public port for a port binding.
  ps          List containers
  pull        Pull service images
  push        Push service images
  restart     Restart service containers
  rm          Removes stopped service containers
  run         Run a one-off command on a service.
  start       Start services
  stop        Stop services
  top         Display the running processes
  unpause     Unpause services
  up          Create and start containers
  version     Show the Docker Compose version information
  wait        Block until the first service container stops

Run 'docker compose COMMAND --help' for more information on a command.
```