### PR TITLE
chore: format and optimize Dockerfiles

### DIFF
--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -1,15 +1,16 @@
 FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND noninteractive
 
 # Install the Docker apt repository
 RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get upgrade --yes && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install --yes ca-certificates
+    apt-get upgrade --yes && \
+    apt-get install --yes ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 COPY docker-archive-keyring.gpg /usr/share/keyrings/docker-archive-keyring.gpg
 COPY docker.list /etc/apt/sources.list.d/docker.list
 
-ENV DEBIAN_FRONTEND noninteractive
 # Install baseline packages
 RUN apt-get update && \
     apt-get install --yes \

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -9,34 +9,36 @@ RUN apt-get update && \
 COPY docker-archive-keyring.gpg /usr/share/keyrings/docker-archive-keyring.gpg
 COPY docker.list /etc/apt/sources.list.d/docker.list
 
+ENV DEBIAN_FRONTEND noninteractive
 # Install baseline packages
 RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
-      bash \
-      build-essential \
-      ca-certificates \
-      containerd.io \
-      curl \
-      docker-ce \
-      docker-ce-cli \
-      docker-buildx-plugin \
-      docker-compose-plugin \
-      htop \
-      locales \
-      man \
-      python3 \
-      python3-pip \
-      software-properties-common \
-      sudo \
-      systemd \
-      systemd-sysv \
-      unzip \
-      vim \
-      wget \
-      rsync && \
+    apt-get install --yes \
+    bash \
+    build-essential \
+    ca-certificates \
+    containerd.io \
+    curl \
+    docker-ce \
+    docker-ce-cli \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    htop \
+    locales \
+    man \
+    python3 \
+    python3-pip \
+    software-properties-common \
+    sudo \
+    systemd \
+    systemd-sysv \
+    unzip \
+    vim \
+    wget \
+    rsync && \
     # Install latest Git using their official PPA
     add-apt-repository ppa:git-core/ppa && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install --yes git
+    apt-get install --yes git \
+    && rm -rf /var/lib/apt/lists/*
 
 # Enables Docker starting with systemd
 RUN systemctl enable docker
@@ -49,11 +51,11 @@ ENV LANG en_US.UTF-8
 
 # Add a user `coder` so that you're not developing as the `root` user
 RUN useradd coder \
-      --create-home \
-      --shell=/bin/bash \
-      --groups=docker \
-      --uid=1000 \
-      --user-group && \
+    --create-home \
+    --shell=/bin/bash \
+    --groups=docker \
+    --uid=1000 \
+    --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 USER coder

--- a/images/base/mirrorlist
+++ b/images/base/mirrorlist
@@ -1,1 +1,0 @@
-Server=https://archive.archlinux.org/repos/2021/02/01/$repo/os/$arch

--- a/images/minimal/Dockerfile.ubuntu
+++ b/images/minimal/Dockerfile.ubuntu
@@ -4,20 +4,18 @@ USER root
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        bash \
-        ca-certificates \
-        curl \
-        git \
-	sudo
-
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd coder \
-        --create-home \
-        --shell=/bin/bash \
-        --uid=1000 \
-        --user-group && \
+    --create-home \
+    --shell=/bin/bash \
+    --uid=1000 \
+    --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
Format and optimize Dockerfiles to reduce size potentially. Combining `&& rm -rf /var/lib/apt/lists/*` with `apt-get install` reduces overall image size by reducing the size of the layer where packages are added.

This reduces the uncompressed image size for `codercom/enterprise-base` size from **1.08** GB to **1.02** GB