### PR TITLE
ci: do not use the paid runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
         run: yarn format:check
 
   images:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     name: images/ubuntu


### PR DESCRIPTION
As we are running the build on the depot.dev we probably do not need a paid GitHub Runner