### PR TITLE
fix(deprecated/vnc): fix broken turbovncserver-security.conf

### DIFF
--- a/deprecated/vnc/Dockerfile.ubuntu
+++ b/deprecated/vnc/Dockerfile.ubuntu
@@ -67,11 +67,7 @@ RUN ln -s /opt/TurboVNC/bin/* /opt/VirtualGL/bin/* /usr/local/bin/
 # This can be ignored as the VNC server manages this lifecycle.  
 RUN vglserver_config -config +s +f +t
 
-RUN echo 'no-remote-connections\n\
-no-httpd\n\
-no-x11-tcp-connections\n\
-no-pam-sessions\n\
-' > /etc/turbovncserver-security.conf
+COPY turbovncserver-security.conf /etc/turbovncserver-security.conf
 
 ENV VNC_SCRIPTS=$VNC_ROOT_DIR/scripts \
   VNC_SETUP_SCRIPTS=$VNC_ROOT_DIR/setup \

--- a/deprecated/vnc/turbovncserver-security.conf
+++ b/deprecated/vnc/turbovncserver-security.conf
@@ -1,0 +1,4 @@
+no-remote-connections
+no-httpd
+no-x11-tcp-connections
+no-pam-sessions


### PR DESCRIPTION
> [!NOTE]
> This image is deprecated and no longer maintained; this fix is being pushed for illustrative purposes only.

Copying the content in this way resulted in raw `\n` sequences ending up in `/etc/turbovncserver-security.conf`. On later versions of Ubuntu (e.g. 22.04) this can cause the VNC desktop to require login, which will be impossible as the Coder user does not have a PAM password set.