### PR TITLE
Switch images to Ubuntu `noble` 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains example images for use with [Coder](https://coder.com/d
 
 - `enterprise-base`: Contains an example image that can be used as a base for
   other images.
-- `enterprise-minimal`: Contains a minimal image that contians only the required
+- `enterprise-minimal`: Contains a minimal image that contains only the required
   utilities for a Coder workspace to bootstrap successfully.
 
 ## Images on Docker Hub

--- a/images/base/docker.list
+++ b/images/base/docker.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu jammy stable
+deb [signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu noble stable

--- a/images/base/ubuntu.Dockerfile
+++ b/images/base/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:noble
 
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
@@ -51,8 +51,9 @@ RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
 # Make typing unicode characters in the terminal work.
 ENV LANG=en_US.UTF-8
 
-# Add a user `coder` so that you're not developing as the `root` user
-RUN useradd coder \
+# Remove the `ubuntu` user and add a user `coder` so that you're not developing as the `root` user
+RUN userdel -r ubuntu && \
+    useradd coder \
     --create-home \
     --shell=/bin/bash \
     --groups=docker \

--- a/images/minimal/ubuntu.Dockerfile
+++ b/images/minimal/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:noble
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,12 +12,16 @@ RUN apt-get update && \
     sudo \
     && rm -rf /var/lib/apt/lists/*
 
-RUN useradd coder \
+# Make typing unicode characters in the terminal work.
+ENV LANG=en_US.UTF-8
+# Remove the `ubuntu` user and add a user `coder` so that you're not developing as the `root` user
+RUN userdel -r ubuntu && \
+    useradd coder \
     --create-home \
     --shell=/bin/bash \
+    --groups=docker \
     --uid=1000 \
     --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
-ENV LANG=en_US.UTF-8
 USER coder

--- a/images/minimal/ubuntu.Dockerfile
+++ b/images/minimal/ubuntu.Dockerfile
@@ -19,7 +19,6 @@ RUN userdel -r ubuntu && \
     useradd coder \
     --create-home \
     --shell=/bin/bash \
-    --groups=docker \
     --uid=1000 \
     --user-group && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd


### PR DESCRIPTION
- Correct a typo in README.md
- Update Docker sources to use 'noble'
- Change base image from Ubuntu 22.04 to 'noble' 24.04