### PR TITLE
feat: add pipx to base image

### DIFF
--- a/images/base/ubuntu.Dockerfile
+++ b/images/base/ubuntu.Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && \
     rsync && \
 # Install latest Git using their official PPA
     add-apt-repository ppa:git-core/ppa && \
-    apt-get install --yes git \
+    apt-get install --yes git && \
     && rm -rf /var/lib/apt/lists/*
 
 # Enables Docker starting with systemd
@@ -61,3 +61,4 @@ RUN userdel -r ubuntu && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 USER coder
+RUN pipx ensurepath # adds user's bin directory to PATH

--- a/images/base/ubuntu.Dockerfile
+++ b/images/base/ubuntu.Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && \
     rsync && \
 # Install latest Git using their official PPA
     add-apt-repository ppa:git-core/ppa && \
-    apt-get install --yes git && \
+    apt-get install --yes git \
     && rm -rf /var/lib/apt/lists/*
 
 # Enables Docker starting with systemd

--- a/images/base/ubuntu.Dockerfile
+++ b/images/base/ubuntu.Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && \
     jq \
     locales \
     man \
-    python3 \
-    python3-pip \
+    pipx \
     software-properties-common \
     sudo \
     systemd \


### PR DESCRIPTION
After #277, the base images come with Python 3.12, which does not let us install a package in the base Python environment. [`pipx`](https://pipx.pypa.io/stable/) allows installing the packages by creating an isolated environment.